### PR TITLE
Add a class for mapping types to Firebase paths

### DIFF
--- a/firebase.cabal
+++ b/firebase.cabal
@@ -1,5 +1,5 @@
 name:                firebase
-version:             0.2.0
+version:             0.2.1
 synopsis:            Firebase REST client
 description:         Firebase REST client
 homepage:            https://github.com/collegevine/firebase#readme
@@ -23,6 +23,7 @@ library
                      , aeson >= 0.9.0.1
                      , http-types >= 0.9
                      , nano-http >= 0.1.1
+                     , text >= 1.2.2.1
   default-language:    Haskell2010
 
 test-suite firebase-test

--- a/firebase.cabal
+++ b/firebase.cabal
@@ -1,5 +1,5 @@
 name:                firebase
-version:             0.2.1
+version:             0.3.0
 synopsis:            Firebase REST client
 description:         Firebase REST client
 homepage:            https://github.com/collegevine/firebase#readme

--- a/src/Database/Firebase/Types.hs
+++ b/src/Database/Firebase/Types.hs
@@ -7,6 +7,9 @@ module Database.Firebase.Types where
 import Control.Applicative ((<$>))
 import Control.Lens.TH
 import Control.Monad (mzero)
+import Network.HTTP.Types.URI
+import Data.Text
+import Data.ByteString.Builder (toLazyByteString)
 import Data.Aeson
 
 type Location = String
@@ -19,6 +22,13 @@ data Firebase = Firebase {
 
 -- |Representation of a Firebase name response to a POST
 newtype Name = Name { unName :: String } deriving Show
+
+class ToLocation a where
+  toSegment :: a -> [Text]
+  toLoc :: a -> Firebase -> String
+  toLoc a (Firebase token rootUrl)= 
+    rootUrl ++ (show . toLazyByteString . encodePathSegments . toSegment $ a)
+
 
 instance FromJSON Name where
     parseJSON (Object v) = Name <$> v .: "name"

--- a/src/Database/Firebase/Types.hs
+++ b/src/Database/Firebase/Types.hs
@@ -24,10 +24,10 @@ data Firebase = Firebase {
 newtype Name = Name { unName :: String } deriving Show
 
 class ToLocation a where
-  toSegment :: a -> [Text]
+  toSegment :: a -> [String]
   toLoc :: a -> Firebase -> String
   toLoc a (Firebase token rootUrl)= 
-    rootUrl ++ (show . toLazyByteString . encodePathSegments . toSegment $ a)
+    rootUrl ++ (show . toLazyByteString . encodePathSegments . Prelude.map pack . toSegment $ a)
 
 
 instance FromJSON Name where


### PR DESCRIPTION
I've been finding it unpleasant to construct url path segments (the `loc` argument) outside of the Firebase API. This just forces users of the Firebase API to also explain how the type maps to their schema.

The main cost here is writing the same type to multiple paths means we'll likely need to use newtypes. Is this too expensive?

Also, note the version bump due to breaking changes in `put`, `patch`, etc...
