### PR TITLE
Add support for GCM messages

### DIFF
--- a/firebase.cabal
+++ b/firebase.cabal
@@ -18,6 +18,7 @@ library
   ghc-options:         -XConstraintKinds
   exposed-modules:     Database.Firebase.Types, Database.Firebase
   build-depends:       base >= 4.7 && < 5
+                     , text >= 1.2.2.1
                      , mtl >= 2.1.3.1
                      , bytestring >= 0.10.6.0
                      , lens >= 4.13

--- a/src/Database/Firebase.hs
+++ b/src/Database/Firebase.hs
@@ -47,6 +47,17 @@ patch loc dta = http' =<< fbReq (CustomMethod "PATCH") loc (mkJSONData dta) Noth
 delete :: (FbHttpM m e r, HasFirebase r) => Location -> m ()
 delete loc = http' =<< fbReq DELETE loc NoRequestData Nothing
 
+sendMessage :: (FbHttpM m e r, HasFirebase r, ToJSON a) => Message a -> m ()
+sendMessage msg = do
+    req <- buildReq POST googleCloudEndpoint (mkJSONData msg)
+    apiKey <- view firebaseToken
+    let req' = addHeaders [json, auth apiKey] req
+    http' req'
+    where 
+        json = ("Content-Type", "application/json")
+        auth t = ("Authorization", "key=" ++ t)
+        googleCloudEndpoint = "https://fcm.googleapis.com/fcm/send"
+
 fbReq :: (FbHttpM m e r, HasFirebase r) => HttpMethod -> Location -> RequestData -> Maybe Query -> m Request
 fbReq mthd loc dta mq = do
     baseURL <- view firebaseURL

--- a/src/Database/Firebase/Types.hs
+++ b/src/Database/Firebase/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Database.Firebase.Types where
 
@@ -13,6 +14,7 @@ import Control.Monad.Except (MonadError)
 import Network.HTTP.Nano
 import Control.Monad.Trans (MonadIO)
 import Data.Aeson
+import qualified Data.Text.Internal as T
 
 type Location = String
 type FBID = String
@@ -37,8 +39,46 @@ data Query = Query {
     limit :: Maybe Limit
 }
 
+data Message a = Message {
+    to                  :: Maybe String,
+    registrationIDs     :: [String],
+    collapseKey         :: Maybe String,
+    priority            :: Priority,
+    contentAvailable    :: Maybe Bool,
+    delayWhileIdle      :: Maybe Bool,
+    ttl                 :: Maybe Int,
+    payload             :: MessageBody a
+}
+
+instance ToJSON a => ToJSON (Message a) where
+    toJSON Message {..} = 
+        omitNulls [ "to" .= toJSON to,
+                    "registration_ids" .= toJSON registrationIDs,
+                    "collapse_key" .= toJSON collapseKey,
+                    "priority" .= toJSON priority,
+                    "content_available" .= toJSON contentAvailable,
+                    "delay_while_idle" .= toJSON delayWhileIdle,
+                    "time_to_live" .= toJSON ttl,
+                    case payload of
+                         Notification x -> "notification" .= toJSON x
+                         Data x -> "data" .= toJSON x
+        ]
+
+data MessageBody a = Notification a | Data a
+
+data Priority = Low | High
+
+instance ToJSON Priority where
+    toJSON Low = String "low"
+    toJSON High = String "high"
+
 data Limit = LimitToFirst Int | LimitToLast Int
 
 data Key = forall a. ToJSON a => Key a
+
+omitNulls :: [(T.Text, Value)] -> Value
+omitNulls = object . filter notNull where
+    notNull (_, Null) = False
+    notNull _         = True  
 
 makeClassy ''Firebase


### PR DESCRIPTION
Google supports routing Google Cloud Messaging via a Firebase key under the guise of `FCM`. This is a simple FCM implementation (not all message features are supported yet).
